### PR TITLE
fix(feed): change data sources

### DIFF
--- a/src/feed.njk
+++ b/src/feed.njk
@@ -3,17 +3,17 @@ permalink: '/feed.xml'
 ---
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
-  <title>{{ site.name }}</title>
+  <title>{{ config.name }}</title>
   <subtitle></subtitle>
-  <link href="{{ site.url }}{{ permalink }}" rel="self"/>
-  <link href="{{ site.url }}/"/>
+  <link href="{{ config.url }}{{ permalink }}" rel="self"/>
+  <link href="{{ config.url }}/"/>
   <updated>{{ collections.posts | rssLastUpdatedDate }}</updated>
-  <id>{{ site.url }}</id>
+  <id>{{ config.url }}</id>
   <author>
-    <name>{{ site.authorName }}</name>
+    <name>{{ config.authorName }}</name>
   </author>
   {% for post in collections.posts %}
-    {% set absolutePostUrl %}{{ site.url }}{{ post.url | url }}{% endset %}
+    {% set absolutePostUrl %}{{ config.url }}{{ post.url | url }}{% endset %}
     <entry>
       <title>{{ post.data.title }}</title>
       <link href="{{ absolutePostUrl }}"/>


### PR DESCRIPTION
Noticed that generated `feed.xml` didn't have full working URL paths because variable names were trying to load data from non-existing JSON data file. Changed the variable names to begin with `config.` to make the XML output generation work properly.

### Before the changes

```xml
<feed xmlns="http://www.w3.org/2005/Atom">
  <title/>
  <subtitle/>
  <link href="/feed.xml" rel="self"/>
  <link href="/"/>
  <updated>2020-03-03T00:00:00-00:00</updated>
  <id/>
   <!--- file continues... --->
```


### Changes done in the pull request

- Change data sources
  - Replace `site.` with `config.`