### PR TITLE
chore: disable Nunjucks autoformatting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,11 @@
 {
   "emmet.includeLanguages": {
-    "njk": "html",
+    "njk": "html"
   },
   "editor.formatOnSave": true,
+  "[njk]": {
+    "editor.formatOnSave": false
+  },
   "markdownlint.config": {
     "MD033": false
   }


### PR DESCRIPTION
## chore: disable Nunjucks autoformatting

- Disable editor autoformatting of Nunjucks files
  because it breaks the front matter structure
  (with at least part of the VS Code autoformatters)

## Reason behind the changes

When doing automatic formatting of `feed.njk` file
(and other Nunjucks files with post front matter),
the outputted front matter gets broken down.

### Before formatting

```html

---
permalink: '/feed.xml'
---
<?xml version="1.0" encoding="utf-8"?>
<feed xmlns="http://www.w3.org/2005/Atom">
  <title>{{ config.name }}</title>
  <subtitle></subtitle>
  <link href="{{ config.url }}{{ permalink }}" rel="self"/>
  <link href="{{ config.url }}/"/>
  <updated>{{ collections.posts | rssLastUpdatedDate }}</updated>
  <id>{{ config.url }}</id>
  <author>
    <name>{{ config.authorName }}</name>
  </author>
  {% for post in collections.posts %}
    {% set absolutePostUrl %}{{ config.url }}{{ post.url | url }}{% endset %}
    <entry>
      <title>{{ post.data.title }}</title>
      <link href="{{ absolutePostUrl }}"/>
      <updated>{{ post.date | rssDate }}</updated>
      <id>{{ absolutePostUrl }}</id>
      <content type="html">
        <![CDATA[
      {{ post.templateContent | safe }}
    ]]>
      </content>
    </entry>
  {% endfor %}
</feed>

```

### After formatting

Front matter turns to "one-liner" that basically breaks down the compilation process.

```html

--- permalink: '/feed.xml' ---
<?xml version="1.0" encoding="utf-8"?>
<feed xmlns="http://www.w3.org/2005/Atom">
  <title>{{ config.name }}</title>
  <subtitle></subtitle>
  <link href="{{ config.url }}{{ permalink }}" rel="self"/>
  <link href="{{ config.url }}/"/>
  <updated>{{ collections.posts | rssLastUpdatedDate }}</updated>
  <id>{{ config.url }}</id>
  <author>
    <name>{{ config.authorName }}</name>
  </author>
  {% for post in collections.posts %}
    {% set absolutePostUrl %}{{ config.url }}{{ post.url | url }}{% endset %}
    <entry>
      <title>{{ post.data.title }}</title>
      <link href="{{ absolutePostUrl }}"/>
      <updated>{{ post.date | rssDate }}</updated>
      <id>{{ absolutePostUrl }}</id>
      <content type="html">
        <![CDATA[
      {{ post.templateContent | safe }}
    ]]>
      </content>
    </entry>
  {% endfor %}
</feed>

```

That is causing Eleventy build process to fail, as `gray-matter` package it uses can't figure out the front matter structure anymore.

```txt

Problem writing Eleventy templates: (more in DEBUG output)
> gray-matter engine "permalink: '/feed.xml' ---" is not registered

`Error` was thrown:
    Error: gray-matter engine "permalink: '/feed.xml' ---" is not registered

```

## Solution

By disabling the formatting on the specific file extension,
we avoid potential build process failures for people using VS Code.

```json
  "editor.formatOnSave": true,
  "[njk]": {
    "editor.formatOnSave": false
  },
```

## Additional notes

Way the `formatOnSave` works depends on what specific formatters are installed on the computer.
While using Prettier for the automatic structure formatting, I noticed that it isn't working as with front matter.
Initially noticed this issue a while ago, but didn't remember that it was still existing on the website project template.
Hopefully this helps if other people have similar issues while using the same project structure.

Other potential solutions could be to figure out how to add proper handling to Prettier itself,
but it is clearly a lot more complex process than just disabling the formatter for the specific types of files.



