### PR TITLE
feat: improve the rel noopener noreferrer setting and add first unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "watch:assets": "parcel watch ./src/assets/css/app.pcss ./src/assets/js/app.js --dist-dir ./bundle --no-source-maps --no-hmr",
     "dev": "yarn watch",
     "update:deps": "yarn upgrade-interactive --latest && yarn upgrade",
-    "update:cssdb": "npx browserslist@latest --update-db"
+    "update:cssdb": "npx browserslist@latest --update-db",
+    "test": "jest"
   },
   "dependencies": {
     "@11ty/eleventy": "0.11.0",
@@ -44,6 +45,7 @@
   },
   "devDependencies": {
     "cross-env": "7.0.2",
+    "jest": "^26.3.0",
     "npm-run-all": "4.1.5",
     "parcel": "^2.0.0-beta.1",
     "postcss-cli": "7.1.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "cross-env": "7.0.2",
-    "jest": "^26.3.0",
+    "jest": "26.3.0",
     "npm-run-all": "4.1.5",
     "parcel": "^2.0.0-beta.1",
     "postcss-cli": "7.1.1",

--- a/utils/transforms/contentParser.js
+++ b/utils/transforms/contentParser.js
@@ -4,10 +4,10 @@ const slugify = require('slugify')
 const eleventyConfig = require('../../src/_data/config.json')
 
 function setClass(element, list) {
-  list.map(item => element.classList.add(item))
+  list.map((item) => element.classList.add(item))
 }
 
-module.exports = function(value, outputPath) {
+module.exports = function (value, outputPath) {
   if (outputPath.endsWith('.html')) {
     /**
      * Create the document model
@@ -20,7 +20,7 @@ module.exports = function(value, outputPath) {
      */
     const images = [...document.querySelectorAll('main article img')]
     if (images.length) {
-      images.forEach(image => {
+      images.forEach((image) => {
         /**
          * Set the loading attribute to all
          * the images to be lazy loaded (if supported)
@@ -72,7 +72,7 @@ module.exports = function(value, outputPath) {
        * Create an anchor element inside each post heading
        * to link to the section
        */
-      articleHeadings.forEach(heading => {
+      articleHeadings.forEach((heading) => {
         // Create the anchor element
         const anchor = document.createElement('a')
         // Create the anchor slug
@@ -94,7 +94,7 @@ module.exports = function(value, outputPath) {
      */
     const articleEmbeds = [...document.querySelectorAll('main article iframe')]
     if (articleEmbeds.length) {
-      articleEmbeds.forEach(embed => {
+      articleEmbeds.forEach((embed) => {
         const wrapper = document.createElement('div')
         embed.setAttribute('loading', 'lazy')
         setClass(wrapper, eleventyConfig.iframeClass)
@@ -108,7 +108,7 @@ module.exports = function(value, outputPath) {
      */
     const codeSnippets = [...document.querySelectorAll('pre[class^="language"')]
     if (codeSnippets.length) {
-      codeSnippets.forEach(embed => {
+      codeSnippets.forEach((embed) => {
         const wrapper = document.createElement('div')
         setClass(wrapper, eleventyConfig.codeClass)
         wrapper.appendChild(embed.cloneNode(true))
@@ -122,7 +122,7 @@ module.exports = function(value, outputPath) {
      */
     const links = [...document.querySelectorAll('a[href]')]
     if (links.length) {
-      links.forEach(link => {
+      links.forEach((link) => {
         /**
          * For each link found get all the original attributes
          * and apply them to the custom link element
@@ -142,15 +142,21 @@ module.exports = function(value, outputPath) {
          * append a "noopener" value to the rel attribute
          */
         const getHref = link.getAttribute('href')
-        const currentRel = link.getAttribute('rel')
-        const isExternal =
-          getHref.startsWith('http') || getHref.startsWith('https')
+        const currentRel = link.getAttribute('rel') || ''
+        const isExternal = getHref.startsWith('http')
         if (isExternal) {
           externalLink.setAttribute(
             'rel',
-            currentRel && !currentRel.includes('noopener')
-              ? `${currentRel} noopener noreferrer`
-              : 'noopener noreferrer'
+            [
+              ...new Set(
+                currentRel
+                  .split(/\s+/)
+                  .filter((relValStr) => relValStr.trim())
+                  .map((relValStr) => relValStr.toLowerCase())
+                  .concat(['noopener', 'noreferrer'])
+                  .sort()
+              ),
+            ].join(' ')
           )
         }
         externalLink.innerHTML = link.innerHTML

--- a/utils/transforms/contentParser.spec.js
+++ b/utils/transforms/contentParser.spec.js
@@ -1,0 +1,287 @@
+const contentParser = require('./contentParser')
+const normaliseEol = (str) => str.replace(/\r?\n/g, '\r\n')
+
+// general sanity check: function(value, outputPath)
+// -----------------------------------------------------------------------------
+test('passes through an empty HTML', () => {
+  const source = `<!DOCTYPE html>
+<html><head></head><body>zzz</body></html>`
+  expect(normaliseEol(contentParser(source, 'file.html'))).toBe(
+    normaliseEol(source)
+  )
+})
+
+// image lazy loading
+// -----------------------------------------------------------------------------
+
+test('sets image lazy loading to one image', () => {
+  const source = `<!DOCTYPE html>
+<html><head></head><body><main><article>
+<img src="spacer.gif" width="1" height="1" alt="test spacer"/>
+</article></main></body></html>`
+  const desired = `<!DOCTYPE html>
+<html><head></head><body><main><article>
+<img src="spacer.gif" width="1" height="1" alt="test spacer" loading="lazy">
+</article></main></body></html>`
+  expect(normaliseEol(contentParser(source, 'file.html'))).toBe(
+    normaliseEol(desired)
+  )
+})
+
+test('sets image lazy loading to two images', () => {
+  const source = `<!DOCTYPE html>
+<html><head></head><body><main><article>
+<img src="spacer1.gif" width="1" height="1" alt="test spacer"><img src="spacer2.gif" width="1" height="1" alt="test spacer">
+</article></main></body></html>`
+  const desired = `<!DOCTYPE html>
+<html><head></head><body><main><article>
+<img src="spacer1.gif" width="1" height="1" alt="test spacer" loading="lazy"><img src="spacer2.gif" width="1" height="1" alt="test spacer" loading="lazy">
+</article></main></body></html>`
+  expect(normaliseEol(contentParser(source, 'file.html'))).toBe(
+    normaliseEol(desired)
+  )
+})
+
+test('respects existing loading attributes', () => {
+  const source = `<!DOCTYPE html>
+<html><head></head><body><main><article>
+<img src="spacer1.gif" width="1" height="1">
+<img src="spacer2.gif" width="1" height="1" loading="lazy">
+<img src="spacer3.gif" width="1" height="1">
+</article></main></body></html>`
+  const desired = `<!DOCTYPE html>
+<html><head></head><body><main><article>
+<img src="spacer1.gif" width="1" height="1" loading="lazy">
+<img src="spacer2.gif" width="1" height="1" loading="lazy">
+<img src="spacer3.gif" width="1" height="1" loading="lazy">
+</article></main></body></html>`
+  expect(normaliseEol(contentParser(source, 'file.html'))).toBe(
+    normaliseEol(desired)
+  )
+})
+
+// replaces images with title with figure and figcaption
+// -----------------------------------------------------------------------------
+
+test('sets title and figure and figcaption to an XHTML markup image', () => {
+  const source = `<!DOCTYPE html>
+<html><head></head><body><main><article>
+<img src="spacer.gif" width="1" height="1" title="xity"/>
+</article></main></body></html>`
+  const desired = `<!DOCTYPE html>
+<html><head></head><body><main><article>
+<figure class="figure"><img src="spacer.gif" width="1" height="1" loading="lazy"><figcaption><small>xity</small></figcaption></figure>
+</article></main></body></html>`
+  expect(normaliseEol(contentParser(source, 'file.html'))).toBe(
+    normaliseEol(desired)
+  )
+})
+
+test('does not touch img tags outside <article>', () => {
+  const source = `<!DOCTYPE html>
+<html><head></head><body>
+<img src="spacer.gif" width="1" height="1" title="xity">
+</body></html>`
+  expect(normaliseEol(contentParser(source, 'file.html'))).toBe(
+    normaliseEol(source)
+  )
+})
+
+// creates an anchor element inside each post heading
+// -----------------------------------------------------------------------------
+
+test('creates anchors inside each post heading', () => {
+  const source = `<!DOCTYPE html>
+<html><head></head><body><main><article>
+<h1>First</h1>
+<h2>Second</h2>
+<h3>Third</h3>
+<h4>Fourth</h4>
+<h5>Fifth</h5>
+<h6>Sixth</h6>
+</article></main></body></html>`
+  const desired = `<!DOCTYPE html>
+<html><head></head><body><main><article>
+<h1>First</h1>
+<h2 id="second">Second<a class="permalink" href="#second">#</a></h2>
+<h3 id="third">Third<a class="permalink" href="#third">#</a></h3>
+<h4 id="fourth">Fourth<a class="permalink" href="#fourth">#</a></h4>
+<h5 id="fifth">Fifth<a class="permalink" href="#fifth">#</a></h5>
+<h6 id="sixth">Sixth<a class="permalink" href="#sixth">#</a></h6>
+</article></main></body></html>`
+  expect(normaliseEol(contentParser(source, 'file.html'))).toBe(
+    normaliseEol(desired)
+  )
+})
+
+test('does not touch the headings outside <article>', () => {
+  const source = `<!DOCTYPE html>
+<html><head></head><body><main>
+<h1>First</h1>
+<h2>Second</h2>
+<h3>Third</h3>
+<h4>Fourth</h4>
+<h5>Fifth</h5>
+<h6>Sixth</h6>
+</main></body></html>`
+  expect(normaliseEol(contentParser(source, 'file.html'))).toBe(
+    normaliseEol(source)
+  )
+})
+
+// wraps all iframes with a class
+// -----------------------------------------------------------------------------
+
+test('puts all iframes in a div container with a custom class', () => {
+  const source = `<!DOCTYPE html>
+<html><head></head><body><main><article>
+<iframe title="Inline Frame Example" width="300" height="200" src="zzz"></iframe>
+</article></main></body></html>`
+  const desired = `<!DOCTYPE html>
+<html><head></head><body><main><article>
+<div class="iframes-wrapper"><iframe title="Inline Frame Example" width="300" height="200" src="zzz" loading="lazy"></iframe></div>
+</article></main></body></html>`
+  expect(normaliseEol(contentParser(source, 'file.html'))).toBe(
+    normaliseEol(desired)
+  )
+})
+
+test('does not touch the iframes outside the <article>', () => {
+  const source = `<!DOCTYPE html>
+<html><head></head><body><main>
+<iframe title="Inline Frame Example" width="300" height="200" src="zzz"></iframe>
+</main></body></html>`
+  expect(normaliseEol(contentParser(source, 'file.html'))).toBe(
+    normaliseEol(source)
+  )
+})
+
+// puts all code snippets in a container
+// -----------------------------------------------------------------------------
+
+test('wraps all pre tags which have language-* class', () => {
+  const source = `<!DOCTYPE html>
+<html><head></head><body>
+<pre class="language-css"><code>.title { color: red; }</code></pre>
+</body></html>`
+  const desired = `<!DOCTYPE html>
+<html><head></head><body>
+<div class="code-wrapper"><pre class="language-css"><code>.title { color: red; }</code></pre></div>
+</body></html>`
+  expect(normaliseEol(contentParser(source, 'file.html'))).toBe(
+    normaliseEol(desired)
+  )
+})
+
+test('does not touch pre tags without language class', () => {
+  const source = `<!DOCTYPE html>
+<html><head></head><body>
+<pre class="lang"><code>.title { color: red; }</code></pre>
+</body></html>`
+  expect(normaliseEol(contentParser(source, 'file.html'))).toBe(
+    normaliseEol(source)
+  )
+})
+
+// adds noopener rel values on anchor hrefs
+// -----------------------------------------------------------------------------
+
+test('adds both noreferrer and noopener when neither exists', () => {
+  const source = `<!DOCTYPE html>
+<html><head></head><body>
+<a href="http://xity-starter.netlify.app/">click me</a>
+</body></html>`
+  expect(contentParser(source, 'file.html')).toEqual(
+    expect.stringContaining(`rel="noopener noreferrer"`)
+  )
+})
+
+test('adds both noreferrer and noopener on empty rel', () => {
+  const source = `<!DOCTYPE html>
+<html><head></head><body>
+<a href="https://xity-starter.netlify.app/" rel="">click me</a>
+</body></html>`
+  expect(contentParser(source, 'file.html')).toEqual(
+    expect.stringContaining(`rel="noopener noreferrer"`)
+  )
+})
+
+test('adds both noreferrer and noopener on rel with a whitespace value', () => {
+  const source = `<!DOCTYPE html>
+<html><head></head><body>
+<a href="http://xity-starter.netlify.app/" rel=" ">click me</a>
+</body></html>`
+  expect(contentParser(source, 'file.html')).toEqual(
+    expect.stringContaining(`rel="noopener noreferrer"`)
+  )
+})
+
+test('adds both noreferrer and noopener on rel without a value', () => {
+  const source = `<!DOCTYPE html>
+<html><head></head><body>
+<a href="https://xity-starter.netlify.app/" rel>click me</a>
+</body></html>`
+  expect(contentParser(source, 'file.html')).toEqual(
+    expect.stringContaining(`rel="noopener noreferrer"`)
+  )
+})
+
+test('adds only noreferrer when rel noopener exists', () => {
+  const source = `<!DOCTYPE html>
+<html><head></head><body>
+<a href="http://xity-starter.netlify.app/" rel="noopener">click me</a>
+</body></html>`
+  expect(contentParser(source, 'file.html')).toEqual(
+    expect.stringContaining(`rel="noopener noreferrer"`)
+  )
+})
+
+test('adds only noopener when rel noreferrer exists', () => {
+  const source = `<!DOCTYPE html>
+<html><head></head><body>
+<a href="https://xity-starter.netlify.app/" rel="noreferrer">click me</a>
+</body></html>`
+  expect(contentParser(source, 'file.html')).toEqual(
+    expect.stringContaining(`rel="noopener noreferrer"`)
+  )
+})
+
+test('does not add noopener or noreferrer when both exist', () => {
+  const source = `<!DOCTYPE html>
+<html><head></head><body>
+<a href="http://xity-starter.netlify.app/" rel="noopener noreferrer">click me</a>
+</body></html>`
+  expect(contentParser(source, 'file.html')).toEqual(
+    expect.stringContaining(`rel="noopener noreferrer"`)
+  )
+})
+
+test('dedupes redundant noopener and noreferrer values in various letter case and normalises the whitespace', () => {
+  const source = `<!DOCTYPE html>
+<html><head></head><body>
+<a href="https://xity-starter.netlify.app/" rel="noopener\t\tnoreferrer\t\tnoOpener\t\tnoReferrer\t\tNOOPENER\t\tNOREFERRER\t\tnOoPeNeR\t\tnOrEfErReR\t\tnoreferrer\t\tnoreferrer">click me</a>
+</body></html>`
+  expect(contentParser(source, 'file.html')).toEqual(
+    expect.stringContaining(`rel="noopener noreferrer"`)
+  )
+})
+
+test('does not add noopener or noreferrer on non-http(s) links', () => {
+  const source = `<!DOCTYPE html>
+<html><head></head><body>
+<a href="mailto:webmaster@mozilla.com">email me</a>
+</body></html>`
+  expect(contentParser(source, 'file.html')).toEqual(
+    expect.not.stringContaining(`rel=`)
+  )
+})
+
+test('does not add noopener or noreferrer on relative links', () => {
+  const source = `<!DOCTYPE html>
+<html><head></head><body>
+<a href="/blog/">see the blog</a>
+</body></html>`
+  expect(contentParser(source, 'file.html')).toEqual(
+    expect.not.stringContaining(`rel=`)
+  )
+})


### PR DESCRIPTION
hi Mattia, Daniel and team,

Here's a tiny PR to kickstart the week.

[x] added Jest — it's quite industry-standard but I can swap it for something else if you guys object
[x] Unit tests for each group in `contentParser`, EOL-normalised
[x] Removed the redundant `startsWith('https')`
[x] Beefed up rel `noopener`/`noreferrer` addition — previously there was a risk of duplication because only `noopener` was checked — now we account for edge cases like repeated values and/or wrong letter case

I ran the code through no-semi/single quote setting Prettier for consistency. We should set up Prettier on JS files in a separate feature ticket ideally.

I didn't wire up `test` script in `package.json` to any of existing tasks deliberately, I leave that up to you.