### PR TITLE
fix: set server error response code in middleware to be 404

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -106,6 +106,9 @@ module.exports = function (eleventyConfig) {
 
         browserSync.addMiddleware('*', (req, res) => {
           // Provides the 404 content without redirect.
+          res.writeHead(404, {
+            'Content-Type': 'text/html'
+          });
           res.write(content_404)
           res.end()
         })


### PR DESCRIPTION
Currently, our error page middleware returns `200` code on 404 page. Let's fix that. Here's "before" and "after":

![correct dev server response 404](https://user-images.githubusercontent.com/8344688/92998666-10026e80-f513-11ea-8bb0-77197af9ab3f.png)

This patch fix will make it return 404. For posterity, here's [`response.writeHead` documentation](https://nodejs.org/api/http.html#http_response_writehead_statuscode_statusmessage_headers).

From a user's standpoint, this might improve the broken URL checks on the _local_ — normally link checkers read the server response code and can't recognise custom 404 pages (even coming from `*/404.html`) which return `200`.

Please review. Thank you.